### PR TITLE
Tricky exception when reopening a campaign

### DIFF
--- a/symfony/src/Controller/CampaignController.php
+++ b/symfony/src/Controller/CampaignController.php
@@ -129,9 +129,12 @@ class CampaignController extends BaseController
     {
         $this->validateCsrfOrThrowNotFoundException('campaign', $csrf);
 
-        // Reopen the campaign
         if (!$campaign->isActive()) {
-            $this->campaignManager->openCampaign($campaign);
+            if (!$this->campaignManager->canReopenCampaign($campaign)) {
+                $this->danger('campaign.cannot_reopen');
+            } else {
+                $this->campaignManager->openCampaign($campaign);
+            }
         }
 
         return $this->redirect($this->generateUrl('communication_index', [

--- a/symfony/src/Entity/Campaign.php
+++ b/symfony/src/Entity/Campaign.php
@@ -64,9 +64,9 @@ class Campaign
     /**
      * @var int
      *
-     * @ORM\Column(type="integer", options={"default" : 1})
+     * @ORM\Column(type="boolean")
      */
-    private $active;
+    private $active = true;
 
     /**
      * @ORM\OneToMany(targetEntity="App\Entity\Communication", mappedBy="campaign", cascade={"persist"})

--- a/symfony/src/Entity/Message.php
+++ b/symfony/src/Entity/Message.php
@@ -85,7 +85,7 @@ class Message
     private $geoLocation;
 
     /**
-     * @ORM\Column(type="string", length=8)
+     * @ORM\Column(type="string", length=8, nullable=true)
      */
     private $prefix;
 

--- a/symfony/src/Manager/CommunicationManager.php
+++ b/symfony/src/Manager/CommunicationManager.php
@@ -112,20 +112,6 @@ class CommunicationManager
             ->setMultipleAnswer($communicationModel->multipleAnswer)
             ->setSubject($communicationModel->subject);
 
-        foreach ($communicationModel->volunteers as $volunteer) {
-            $message = new Message();
-
-            $message->setPrefix(
-                $this->messageManager->generatePrefix($volunteer)
-            );
-
-            $message->setCode(
-                $this->messageManager->generateCode()
-            );
-
-            $communicationEntity->addMessage($message->setVolunteer($volunteer));
-        }
-
         // The first choice key is always "1"
         $choiceKey = 1;
         foreach (array_unique($communicationModel->answers) as $choiceValue) {
@@ -136,6 +122,22 @@ class CommunicationManager
 
             $communicationEntity->addChoice($choice);
             $choiceKey++;
+        }
+
+        foreach ($communicationModel->volunteers as $volunteer) {
+            $message = new Message();
+
+            if (1 !== $choiceKey) {
+                $message->setPrefix(
+                    $this->messageManager->generatePrefix($volunteer)
+                );
+            }
+
+            $message->setCode(
+                $this->messageManager->generateCode()
+            );
+
+            $communicationEntity->addMessage($message->setVolunteer($volunteer));
         }
 
         return $communicationEntity;

--- a/symfony/src/Manager/MessageManager.php
+++ b/symfony/src/Manager/MessageManager.php
@@ -237,4 +237,14 @@ class MessageManager
     {
         $this->messageRepository->cancelAnswerByChoice($message, $choice);
     }
+
+    /**
+     * @param array $volunteersTakenPrefixes
+     *
+     * @return bool
+     */
+    public function canUsePrefixesForEveryone(array $volunteersTakenPrefixes): bool
+    {
+        return $this->messageRepository->canUsePrefixesForEveryone($volunteersTakenPrefixes);
+    }
 }

--- a/symfony/src/Migrations/Version20200127190654.php
+++ b/symfony/src/Migrations/Version20200127190654.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200127190654 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE message CHANGE prefix prefix VARCHAR(8) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE message CHANGE prefix prefix VARCHAR(8) CHARACTER SET utf8mb4 NOT NULL COLLATE `utf8mb4_unicode_ci`');
+    }
+}

--- a/symfony/src/Migrations/Version20200127191854.php
+++ b/symfony/src/Migrations/Version20200127191854.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200127191854 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE campaign CHANGE active active TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE campaign CHANGE active active INT DEFAULT 1 NOT NULL');
+    }
+}

--- a/symfony/src/Repository/CampaignRepository.php
+++ b/symfony/src/Repository/CampaignRepository.php
@@ -51,7 +51,7 @@ class CampaignRepository extends BaseRepository
             ->innerJoin('s.users', 'u')
             ->where('u.user = :user')
             ->setParameter('user', $user)
-            ->andWhere('c.active = 1');
+            ->andWhere('c.active = true');
     }
 
     /**
@@ -67,7 +67,7 @@ class CampaignRepository extends BaseRepository
             ->innerJoin('s.users', 'u')
             ->where('u.user = :user')
             ->setParameter('user', $user)
-            ->andWhere('c.active = 0');
+            ->andWhere('c.active = false');
     }
 
     /**

--- a/symfony/translations/messages.en.yml
+++ b/symfony/translations/messages.en.yml
@@ -99,6 +99,7 @@ campaign:
     label: Label
     type: Color
     created_at: Creation date
+  cannot_reopen: 'Impossible to reopen the campaign: since it was closed, one or several volunteers were triggered and prefix used for their answers was reused.'
 
 campaign_status:
   communication_tabs: Communications

--- a/symfony/translations/messages.fr.yml
+++ b/symfony/translations/messages.fr.yml
@@ -93,6 +93,7 @@ campaign:
     label: Intitulé
     type: Couleur
     created_at: Date de création
+  cannot_reopen: 'Impossible de réouvrir le déclenchement : depuis sa fermeure, un ou plusieurs volontaires ont été déclenchés et le préfixe associé à leur réponse a été réuilisé.'
 
 modal:
   change_color: Changer de couleur...


### PR DESCRIPTION
If a campaign with one communication to one volunteer used prefix "A"
has been closed, next time volunteer will be triggered will also use
prefix "A". Thus, it should not be possible to reopen a campaign if
a prefix, from any volunteer and from any message of the communication
has been reused in a following campaign that is still open.