### PR TITLE
integrate the main deploy.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ archives.txt
 
 TestCommand.php
 /gcp/cloudFunctions/twilioWebhooks/node_modules/
+!/deploy/protec/

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ archives.txt
 
 TestCommand.php
 /gcp/cloudFunctions/twilioWebhooks/node_modules/
-!/deploy/protec/

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -53,6 +53,11 @@ cd ..
 # Cron jobs
 gcloud app deploy --quiet symfony/cron.yaml
 
+#Cloud Functions
+cd gcp/deploy/ || exit
+./deploy.sh
+cd --          || exit
+
 # Restoring current context
 cp deploying/.env symfony/.env
 cp deploying/google-service-account.json symfony/config/keys/google-service-account.json

--- a/gcp/deploy/deploy.sh
+++ b/gcp/deploy/deploy.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
-
 #This script deploys the cloud function twice, one per endpoint (sms status, sms response)
+
+#if GCP_PROJECT_NAME is defined, we're being called by the main deployment scripts and env vars are defined
+if [ ! -d "${GCP_PROJECT_NAME}" ]
+then
+  ENV=$1
+  if  [[ "${ENV}1" != "preprod1" ]] && [[ "${ENV}1" != "prod1" ]]
+  then
+    echo "'${ENV}' is not a valid environment. 'preprod' & 'prod' are allowed"
+    exit 1
+  fi
+
+  source "../../deploy/${ENV}/dotenv"
+fi
 
 #https://cloud.google.com/functions/docs/env-var
 
@@ -13,12 +25,12 @@ sed -i '' -e "s/¤CloudFunctioName¤/webHooksToTasksSMSStatus/g"  /tmp/twilioWeb
 cd /tmp/twilioWebhooks/ || exit
 
 gcloud functions deploy webHooksToTasksSMSStatus \
-  --service-account cf-twilio-webhook@redcall-dev.iam.gserviceaccount.com \
+  --service-account "cf-twilio-webhook@${GCP_PROJECT_NAME}.iam.gserviceaccount.com" \
   --trigger-http \
   --allow-unauthenticated \
   --runtime nodejs10 \
   --region europe-west1 \
-  --set-env-vars TASK_QUEUE_LOCATION=europe-west1,TASK_QUEUE_NAME=webhook-sms-status,PROJECT_ID=redcall-dev
+  --set-env-vars "TASK_QUEUE_LOCATION=europe-west1,TASK_QUEUE_NAME=webhook-sms-status,PROJECT_ID=${GCP_PROJECT_NAME}"
 
 cd - || exit
 rm -rf /tmp/twilioWebhooks/*
@@ -28,12 +40,12 @@ cd /tmp/twilioWebhooks/ || exit
 sed -i '' -e "s/¤CloudFunctioName¤/webHooksToTasksSMSResponse/g"  /tmp/twilioWebhooks/index.js
 
 gcloud functions deploy webHooksToTasksSMSResponse \
-  --service-account cf-twilio-webhook@redcall-dev.iam.gserviceaccount.com \
+  --service-account "cf-twilio-webhook@${GCP_PROJECT_NAME}.iam.gserviceaccount.com" \
   --trigger-http \
   --allow-unauthenticated \
   --runtime nodejs10 \
   --region europe-west1 \
-  --set-env-vars TASK_QUEUE_LOCATION=europe-west1,TASK_QUEUE_NAME=webhook-sms-responses,PROJECT_ID=redcall-dev
+  --set-env-vars "TASK_QUEUE_LOCATION=europe-west1,TASK_QUEUE_NAME=webhook-sms-responses,PROJECT_ID=${GCP_PROJECT_NAME}"
 
 cd - || exit
 

--- a/gcp/deploy/init/init_api.sh
+++ b/gcp/deploy/init/init_api.sh
@@ -5,6 +5,15 @@
 # * create a service account and set the appropriate right to run the cloud functions
 # * create the cloud tasks queues
 
+ENV=$1
+if  [[ "${ENV}1" != "preprod1" ]] && [[ "${ENV}1" != "prod1" ]]
+then
+  echo "'${ENV}' is not a valid environment. 'preprod' & 'prod' are allowed"
+  exit 1
+fi
+source "../../../deploy/${ENV}/dotenv"
+
+echo "initializing GCP Project : ${GCP_PROJECT_NAME}"
 
 #Cloud Functions
 echo "gcloud services enable cloudfunctions.googleapis.com"
@@ -16,16 +25,18 @@ gcloud services enable cloudtasks.googleapis.com
 
 
 #https://cloud.google.com/iam/docs/creating-managing-service-accounts#iam-service-accounts-create-gcloud
+echo "Creating cf-twilio-webhook service account"
 gcloud iam service-accounts create cf-twilio-webhook \
     --description="Service Account for the cloud function 'twilio-webhook' that recieve twilio webhook " \
     --display-name="Cloud Function twilio-webhook SA"
-
-gcloud projects add-iam-policy-binding redcall-dev \
-  --member serviceAccount:cf-twilio-webhook@redcall-dev.iam.gserviceaccount.com \
+echo "Add role to service account: roles/appengine.appViewer"
+gcloud projects add-iam-policy-binding "${GCP_PROJECT_NAME}" \
+  --member "serviceAccount:cf-twilio-webhook@${GCP_PROJECT_NAME}.iam.gserviceaccount.com" \
   --role roles/cloudtasks.enqueuer
 
-gcloud projects add-iam-policy-binding redcall-dev \
-  --member serviceAccount:cf-twilio-webhook@redcall-dev.iam.gserviceaccount.com \
+echo "Add role to service account: roles/appengine.appViewer"
+gcloud projects add-iam-policy-binding "${GCP_PROJECT_NAME}" \
+  --member "serviceAccount:cf-twilio-webhook@${GCP_PROJECT_NAME}.iam.gserviceaccount.com" \
   --role roles/appengine.appViewer
 
 #https://cloud.google.com/tasks/docs/configuring-queues


### PR DESCRIPTION
Allow scripts to be called outside of the main script, as cloudFunction deployment may be done more often or less often.

Use the dotenv vars for Service Account naming and Cloud Function env vars